### PR TITLE
Fix to trim whitespace from post_types argument

### DIFF
--- a/wordpress-popular-posts.php
+++ b/wordpress-popular-posts.php
@@ -1479,6 +1479,7 @@ if ( !class_exists('WordpressPopularPosts') ) {
 				if ( count($types) > 1 ) {
 
 					foreach ( $types as $post_type ) {
+						$post_type = trim($post_type); // required in case user places whitespace between commas
 						$sql_post_types .= "'{$post_type}',";
 					}
 


### PR DESCRIPTION
The `post_type` argument was being passed into the DB query "as is" (ie: without "validation").

Unfortunately this didn't account for scenarios where the developer passed the post_types parameter with whitespace between each delineating comma.

For example:

```php
post_types=posttype1, posttype2
```

Fix applied to use `trim()` to remove all whitespace from provided `post_types` *before* usage in SQL query.