### PR TITLE
Add compatibiliy with Polylang

### DIFF
--- a/wordpress-popular-posts.php
+++ b/wordpress-popular-posts.php
@@ -1394,7 +1394,12 @@ if ( !class_exists('WordpressPopularPosts') ) {
 			// WPML support, get original post/page ID
 			if ( defined('ICL_LANGUAGE_CODE') && function_exists('icl_object_id') ) {
 				global $sitepress;
-				$id = icl_object_id( $id, get_post_type( $id ), true, $sitepress->get_default_language() );
+				if ( isset( $sitepress )) { // avoids a fatal error with Polylang
+					$id = icl_object_id( $id, get_post_type( $id ), true, $sitepress->get_default_language() );
+				}
+				else if ( function_exists( 'pll_default_language' ) ) { // adds Polylang support
+					$id = icl_object_id( $id, get_post_type( $id ), true, pll_default_language() );
+				}
 			}
 
 			$now = $this->__now();


### PR DESCRIPTION
Hi!

The 'ICL_LANGUAGE_CODE' and the function 'icl_object_id' exist in Polylang but the $sitepress object does not exist, thus causing a fatal error when WordPress Popular Posts is used together with Polylang.

Polylang equivalent to WPML $sitepress->get_default_language() is pll_default_language()

I review all the calls to icl_object_id() and only one is using the $sitepress object. So I guess that this simple change should allow Polylang to inherit all the WPML compatibility code.