### PR TITLE
Fix for notice in WooCommerce wizard

### DIFF
--- a/wordpress-popular-posts.php
+++ b/wordpress-popular-posts.php
@@ -672,7 +672,7 @@ if ( !class_exists('WordpressPopularPosts') ) {
 			}
 
 			$screen = get_current_screen();
-			if ( $screen->id == $this->plugin_screen_hook_suffix ) {
+			if ( isset( $screen->id ) && $screen->id == $this->plugin_screen_hook_suffix ) {
 				wp_enqueue_style( $this->plugin_slug .'-admin-styles', plugins_url( 'style/admin.css', __FILE__ ), array(), $this->version );
 			}
 


### PR DESCRIPTION
There is a notice in WooCommerce wizard:
`Notice: Trying to get property of non-object in /var/www/html/beta/wp-content/plugins/wordpress-popular-posts/wordpress-popular-posts.php on line 675`
I use:
- WordPress v4.7.3
- PHP 7.0.16
- WooCommerce v2.6.14
- WordPress Popular Posts v3.3.4