### PR TITLE
Remove empty spaces before saving post type option.

### DIFF
--- a/wordpress-popular-posts.php
+++ b/wordpress-popular-posts.php
@@ -539,7 +539,7 @@ if ( !class_exists('WordpressPopularPosts') ) {
 			// user did not define the custom post type name, so we fall back to default
 			$instance['post_type'] = ( '' == $new_instance['post_type'] )
 			  ? 'post,page'
-			  : $new_instance['post_type'];
+			  : trim($new_instance['post_type']);
 
 			$instance['freshness'] = isset( $new_instance['freshness'] );
 


### PR DESCRIPTION
 Prevents bug when one custom post type is provided with white space.