### PR TITLE
Improve where statement filtering.

### DIFF
--- a/includes/class-wordpress-popular-posts-query.php
+++ b/includes/class-wordpress-popular-posts-query.php
@@ -410,7 +410,7 @@ class WPP_Query {
             $fields = apply_filters( 'wpp_query_fields', $fields, $this->options );
             $table = apply_filters( 'wpp_query_table', $table, $this->options );
             $join = apply_filters( 'wpp_query_join', $join, $this->options );
-            $where = apply_filters( 'wpp_query_where', $where, $this->options );
+            $where = apply_filters( 'wpp_query_where', $where, $this->options, $args );
             $groupby = apply_filters( 'wpp_query_group_by', $groupby, $this->options );
             $orderby = apply_filters( 'wpp_query_order_by', $orderby, $this->options );
             $limit = apply_filters( 'wpp_query_limit', $limit, $this->options );


### PR DESCRIPTION
In case if you want to modify default "where" statement you will fail since the query preparation is not working if there is `wpp_query_where` filter set. The only possible way in current implementation is to perform arguments (prefixed with "%") replacing in custom `wpp_query_where` filter, but arguments are not available there. So the solution is to send also arguments (`$args`) to filter function.