### PR TITLE
Add exclude current post functionality

### DIFF
--- a/includes/class-wordpress-popular-posts-query.php
+++ b/includes/class-wordpress-popular-posts-query.php
@@ -218,6 +218,10 @@ class WPP_Query {
 
             }
 
+            if( isset($this->options['exclude_current']) && $this->options['exclude_current']){
+                $this->options['pid'] = get_the_ID();
+            }
+
             // Exclude these entries from the listing
             if ( isset($this->options['pid']) && !empty($this->options['pid']) ) {
 

--- a/includes/class-wordpress-popular-posts-settings.php
+++ b/includes/class-wordpress-popular-posts-settings.php
@@ -42,6 +42,7 @@ class WPP_Settings {
             'cat' => '',
             'taxonomy' => 'category',
             'term_id' => '',
+            'exclude_current' => false,
             'shorten_title' => array(
                 'active' => false,
                 'length' => 25,

--- a/includes/class-wordpress-popular-posts-widget.php
+++ b/includes/class-wordpress-popular-posts-widget.php
@@ -218,6 +218,8 @@ class WPP_Widget extends WP_Widget {
             $instance['author'] = implode( ",", $ids );
         }
 
+        $instance['exclude_current'] = $new_instance['exclude_current'];
+
         $instance['shorten_title']['words'] = $new_instance['shorten_title-words'];
         $instance['shorten_title']['active'] = isset( $new_instance['shorten_title-active'] );
         $instance['shorten_title']['length'] = ( WPP_Helper::is_number($new_instance['shorten_title-length']) && $new_instance['shorten_title-length'] > 0 )

--- a/includes/widget-form.php
+++ b/includes/widget-form.php
@@ -85,6 +85,10 @@ if ( $taxonomies = get_taxonomies( array('public' => true), 'objects' ) ) {
     <input type="checkbox" class="checkbox" <?php echo ($instance['rating']) ? 'checked="checked"' : ''; ?> id="<?php echo $this->get_field_id( 'rating' ); ?>" name="<?php echo $this->get_field_name( 'rating' ); ?>" /> <label for="<?php echo $this->get_field_id( 'rating' ); ?>"><?php _e('Display post rating', 'wordpress-popular-posts'); ?></label> <small>[<a href="https://github.com/cabrerahector/wordpress-popular-posts/wiki/5.-FAQ#what-does-display-post-rating-do" title="<?php _e('What is this?', 'wordpress-popular-posts'); ?>" target="_blank">?</a>]</small>
 </div>
 
+<input type="checkbox" class="checkbox" <?php echo ($instance['exclude_current']) ? 'checked="checked"' : ''; ?> id="<?php echo $this->get_field_id( 'exclude_current' ); ?>" name="<?php echo $this->get_field_name( 'exclude_current' ); ?>" /> <label for="<?php echo $this->get_field_id( 'exclude_current' ); ?>"><?php _e('Exclude current post', 'wordpress-popular-posts'); ?></label>
+<br />
+<br />
+
 <input type="checkbox" class="checkbox" <?php echo ($instance['shorten_title']['active']) ? 'checked="checked"' : ''; ?> id="<?php echo $this->get_field_id( 'shorten_title-active' ); ?>" name="<?php echo $this->get_field_name( 'shorten_title-active' ); ?>" /> <label for="<?php echo $this->get_field_id( 'shorten_title-active' ); ?>"><?php _e('Shorten title', 'wordpress-popular-posts'); ?></label><br />
 
 <div style="display:<?php if ($instance['shorten_title']['active']) : ?>block<?php else: ?>none<?php endif; ?>; width:90%; margin:10px 0; padding:3% 5%; background:#f5f5f5;">


### PR DESCRIPTION
It would be great if that was a feature that we could hide the current post from the results.

I needed this functionality and i couldn't find any workaround for this in the forums and in the web and had notice that was more people asking for this functionality.

I saw people hiding the current posts via css with this workaround ```.wpp-list .current{display:none !important;}``` but in reality this was only hiding the post and reducing the results in one.

I wanted that the result was excluded in the query, not affecting the number of the results and only in some of the instances so that in this way i could have an option to choose in which instance i excluded the current post from the results.

So i added a field called ```exclude_current ``` that have the option to exclude from the query and injecting the ```get_the_ID()``` before the ```pid``` filtering.

Im not really sure if im using the best practices that you are using at the moment but is working as expected in my website and it was running nice in tests.
