### PR TITLE
add support of multiple taxonomies filtering

### DIFF
--- a/src/Front/Front.php
+++ b/src/Front/Front.php
@@ -314,7 +314,7 @@ class Front {
             'pid' => rtrim(preg_replace('|[^0-9,]|', '', $pid), ","),
             'cat' => rtrim(preg_replace('|[^0-9,-]|', '', $cat), ","),
             'taxonomy' => empty($taxonomy) ? 'category' : $taxonomy,
-            'term_id' => rtrim(preg_replace('|[^0-9,-]|', '', $term_id), ","),
+            'term_id' => rtrim(preg_replace('|[^0-9,;-]|', '', $term_id), ","),
             'author' => rtrim(preg_replace('|[^0-9,]|', '', $author), ","),
             'shorten_title' => [
                 'active' => ( ! empty($title_length) && Helper::is_number($title_length) && $title_length > 0 ),

--- a/src/Query.php
+++ b/src/Query.php
@@ -144,31 +144,28 @@ class Query {
 
             // Get / exclude entries from this taxonomies
             if (
-                ( isset($this->options['cat']) && ! empty($this->options['cat']) )
-                || ( isset($this->options['term_id']) && ! empty($this->options['term_id']) )
+                ( isset($this->options['taxonomy']) && ! empty($this->options['taxonomy']) ) &&
+                ( ( isset($this->options['cat']) && ! empty($this->options['cat']) )
+                || ( isset($this->options['term_id']) && ! empty($this->options['term_id']) ) )
             ) {
+
+                if ( isset($this->options['cat']) && ! empty($this->options['cat']) ) {
+                    $this->options['term_id'] = $this->options['cat'];
+                }
 
                 $taxonomies = explode(";", $this->options['taxonomy']);
                 $term_IDs_for_taxonomies = explode( ";", $this->options['term_id'] );
 
                 if ( count($taxonomies) == count($term_IDs_for_taxonomies) ) {
 
-                    if ( isset($this->options['taxonomy']) && ! empty($this->options['taxonomy']) ) {
-                        $registered_taxonomies = get_taxonomies(['public' => true]);
+                    $registered_taxonomies = get_taxonomies(['public' => true]);
 
-                        foreach ( $taxonomies as $index => $taxonomy ) {
-                            // Invalid taxonomy, fallback to "category"
-                            if ( ! isset($registered_taxonomies[$taxonomy]) ) {
-                                $this->options['taxonomy'] = 'category';
-                            }
+                    foreach ( $taxonomies as $index => $taxonomy ) {
+                        // Invalid taxonomy, discard the taxonomy
+                        if ( ! isset($registered_taxonomies[$taxonomy]) ) {
+                            unset($taxonomies[$index]);
+                            unset($term_IDs_for_taxonomies[$index]);
                         }
-                    } // Default to "category"
-                    else {
-                        $this->options['taxonomy'] = 'category';
-                    }
-
-                    if ( isset($this->options['cat']) && ! empty($this->options['cat']) ) {
-                        $this->options['term_id'] = $this->options['cat'];
                     }
 
                     $term_IDs = array();
@@ -196,7 +193,7 @@ class Query {
                     }
 
 
-                    foreach( explode(";", $this->options['taxonomy']) as $taxIndex => $taxonomy ) {
+                    foreach( $taxonomies as $taxIndex => $taxonomy ) {
                         $in_term_IDs = $in_term_IDs_for_taxonomies[$taxIndex];
                         $out_term_IDs = $out_term_IDs_for_taxonomies[$taxIndex];
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -142,105 +142,109 @@ class Query {
 
             }
 
-            // Get / exclude entries from this taxonomy
+            // Get / exclude entries from this taxonomies
             if (
                 ( isset($this->options['cat']) && ! empty($this->options['cat']) )
                 || ( isset($this->options['term_id']) && ! empty($this->options['term_id']) )
             ) {
 
-                if ( isset($this->options['taxonomy']) && ! empty($this->options['taxonomy']) ) {
-                    $registered_taxonomies = get_taxonomies(['public' => true]);
-
-                    $taxonomies = explode(";", $this->options['taxonomy']);
-
-                    foreach ( $taxonomies as $taxonomy ) {
-                        // Invalid taxonomy, fallback to "category"
-                        if ( ! isset($registered_taxonomies[$taxonomy]) ) {
-                            $this->options['taxonomy'] = 'category';
-                        }
-                    }
-                } // Default to "category"
-                else {
-                    $this->options['taxonomy'] = 'category';
-                }
-
-                if ( isset($this->options['cat']) && ! empty($this->options['cat']) ) {
-                    $this->options['term_id'] = $this->options['cat'];
-                }
-
+                $taxonomies = explode(";", $this->options['taxonomy']);
                 $term_IDs_for_taxonomies = explode( ";", $this->options['term_id'] );
-                $term_IDs = array();
-                foreach( $term_IDs_for_taxonomies as $term_IDs_for_single_taxonomy ) {
-                     $term_IDs[] = explode( ",", $term_IDs_for_single_taxonomy );
-                }
-                $in_term_IDs_for_taxonomies = array();
-                $out_term_IDs_for_taxonomies = array();
 
-                foreach( $term_IDs as $term_IDs_for_single_taxonomy ) {
+                if ( count($taxonomies) == count($term_IDs_for_taxonomies) ) {
 
-                    $in_term_IDs_for_taxonomy = [];
-                    $out_term_IDs_for_taxonomy = [];
+                    if ( isset($this->options['taxonomy']) && ! empty($this->options['taxonomy']) ) {
+                        $registered_taxonomies = get_taxonomies(['public' => true]);
 
-                    foreach ( $term_IDs_for_single_taxonomy as $term_ID ) {
-
-                        if ( $term_ID >= 0 )
-                            $in_term_IDs_for_taxonomy[] = trim( $term_ID );
-                        else
-                            $out_term_IDs_for_taxonomy[] = trim( $term_ID ) * -1;
-
+                        foreach ( $taxonomies as $index => $taxonomy ) {
+                            // Invalid taxonomy, fallback to "category"
+                            if ( ! isset($registered_taxonomies[$taxonomy]) ) {
+                                $this->options['taxonomy'] = 'category';
+                            }
+                        }
+                    } // Default to "category"
+                    else {
+                        $this->options['taxonomy'] = 'category';
                     }
-                    $in_term_IDs_for_taxonomies[] = $in_term_IDs_for_taxonomy;
-                    $out_term_IDs_for_taxonomies[] = $out_term_IDs_for_taxonomy;
-                }
+
+                    if ( isset($this->options['cat']) && ! empty($this->options['cat']) ) {
+                        $this->options['term_id'] = $this->options['cat'];
+                    }
+
+                    $term_IDs = array();
+                    foreach( $term_IDs_for_taxonomies as $term_IDs_for_single_taxonomy ) {
+                        $term_IDs[] = explode( ",", $term_IDs_for_single_taxonomy );
+                    }
+                    $in_term_IDs_for_taxonomies = array();
+                    $out_term_IDs_for_taxonomies = array();
+
+                    foreach( $term_IDs as $term_IDs_for_single_taxonomy ) {
+
+                        $in_term_IDs_for_taxonomy = [];
+                        $out_term_IDs_for_taxonomy = [];
+
+                        foreach ( $term_IDs_for_single_taxonomy as $term_ID ) {
+
+                            if ( $term_ID >= 0 )
+                                $in_term_IDs_for_taxonomy[] = trim( $term_ID );
+                            else
+                                $out_term_IDs_for_taxonomy[] = trim( $term_ID ) * -1;
+
+                        }
+                        $in_term_IDs_for_taxonomies[] = $in_term_IDs_for_taxonomy;
+                        $out_term_IDs_for_taxonomies[] = $out_term_IDs_for_taxonomy;
+                    }
 
 
-                foreach( explode(";", $this->options['taxonomy']) as $taxIndex => $taxonomy ) {
-                    $in_term_IDs = $in_term_IDs_for_taxonomies[$taxIndex];
-                    $out_term_IDs = $out_term_IDs_for_taxonomies[$taxIndex];
+                    foreach( explode(";", $this->options['taxonomy']) as $taxIndex => $taxonomy ) {
+                        $in_term_IDs = $in_term_IDs_for_taxonomies[$taxIndex];
+                        $out_term_IDs = $out_term_IDs_for_taxonomies[$taxIndex];
 
-                    if (!empty($in_term_IDs)) {
+                        if (!empty($in_term_IDs)) {
 
-                        $where .= " AND p.ID IN (
+                            $where .= " AND p.ID IN (
                         SELECT object_id
                         FROM `{$wpdb->term_relationships}` AS r
                              JOIN `{$wpdb->term_taxonomy}` AS x ON x.term_taxonomy_id = r.term_taxonomy_id
                         WHERE x.taxonomy = '{$taxonomy}'";
 
-                        $inTID = '';
+                            $inTID = '';
 
-                        foreach ($in_term_IDs as $in_term_ID) {
-                            $inTID .= "%d, ";
-                            array_push($args, $in_term_ID);
+                            foreach ($in_term_IDs as $in_term_ID) {
+                                $inTID .= "%d, ";
+                                array_push($args, $in_term_ID);
+                            }
+
+                            $where .= " AND x.term_id IN(" . rtrim($inTID, ", ") . ") )";
                         }
 
-                        $where .= " AND x.term_id IN(" . rtrim($inTID, ", ") . ") )";
-                    }
+                        if (!empty($out_term_IDs)) {
 
-                    if (!empty($out_term_IDs)) {
-
-                        $post_ids = get_posts(
-                            array(
-                                'post_type' => $post_types,
-                                'posts_per_page' => -1,
-                                'tax_query' => array(
-                                    array(
-                                        'taxonomy' => $taxonomy,
-                                        'field' => 'id',
-                                        'terms' => $out_term_IDs,
+                            $post_ids = get_posts(
+                                array(
+                                    'post_type' => $post_types,
+                                    'posts_per_page' => -1,
+                                    'tax_query' => array(
+                                        array(
+                                            'taxonomy' => $taxonomy,
+                                            'field' => 'id',
+                                            'terms' => $out_term_IDs,
+                                        ),
                                     ),
-                                ),
-                                'fields' => 'ids'
-                            )
-                        );
+                                    'fields' => 'ids'
+                                )
+                            );
 
-                        if (is_array($post_ids) && !empty($post_ids)) {
-                            if (isset($this->options['pid']) && !empty($this->options['pid'])) {
-                                $this->options['pid'] .= "," . implode(",", $post_ids);
-                            } else {
-                                $this->options['pid'] = implode(",", $post_ids);
+                            if (is_array($post_ids) && !empty($post_ids)) {
+                                if (isset($this->options['pid']) && !empty($this->options['pid'])) {
+                                    $this->options['pid'] .= "," . implode(",", $post_ids);
+                                } else {
+                                    $this->options['pid'] = implode(",", $post_ids);
+                                }
                             }
                         }
                     }
+
                 }
             }
 


### PR DESCRIPTION
The code is added into my project a while. It works fine. Please consider to add the support of multiple taxonomies filter. One sample shortcode of update is: [wpp taxonomy='taxA;taxB' term_id='-19114,-2221;1024].

