### PR TITLE
Add "wpp_post_title" filter for updating post_title manually

### DIFF
--- a/src/Output.php
+++ b/src/Output.php
@@ -278,6 +278,8 @@ class Output {
             $post_title = Helper::truncate($post_title, $length, $this->public_options['shorten_title']['words'], $this->more);
         }
 
+        $post_title = apply_filters('wpp_post_title', $post_title, $post_object);
+
         // Thumbnail
         $post_thumbnail = $this->get_thumbnail($post_object);
 


### PR DESCRIPTION
For rendering post output, I wish the plugin would add a filter, so that custom style / prefix / suffix can be added on output of each post. 

I have added and used the hook in my project. It helps me add border with **different colour** (based on the taxonomies value of post). Also, suffix of book author is added, with grey colour. 

I believe adding the hook could make the plugin more custom-able.

I understand "wpp_post" filter is existing. It would make entire update of post output. However, I believe it is not the most convenient and compatible for user. It is because when user makes minor changes, it is no need to clone the existing "render_post" function and make minor changes (unnecessary overhead of run similar code twice).  Also, if the "render_post" function is changed in upcoming release, the user customized code for "wpp_post" filter may cause error.

Wish you may add the hook so that help programmer develop with wordpress-popular-posts. Thanks