### PR TITLE
in case of wpml installation we get the correct post_id of the post v…

### DIFF
--- a/src/Front/Front.php
+++ b/src/Front/Front.php
@@ -168,7 +168,7 @@ class Front {
             $post_ID,
             get_post_type($post_ID),
             true,
-            $this->translate->get_default_language()
+            $this->translate->get_current_language()
         );
         $now = Helper::now();
         $curdate = Helper::curdate();

--- a/src/Rest/Controller.php
+++ b/src/Rest/Controller.php
@@ -132,7 +132,7 @@ class Controller extends \WP_REST_Controller {
             $post_ID,
             get_post_type($post_ID),
             true,
-            $this->translate->get_default_language()
+            $this->translate->get_current_language()
         );
 
         $now = Helper::now();


### PR DESCRIPTION
In case of wpml installation get write in db the wrong post_id ( the default language's post id )

Let's suppose that i have a default language in wpml as eng
1) Create a post in one language ( eng ) and create it's translation ( ita )
2)Visit both language version
3) From the db you can't see the visit from the ita version of the post and instead, you have one more visit from the eng version of that post. 

[ISSUE](https://github.com/cabrerahector/wordpress-popular-posts/issues/227)

**Environment:**
 - WordPress version:4.9
 - PHP version: 7.2
 - Plugin version: 5.0

