### PR TITLE
Giovanni current language wpml

### DIFF
--- a/src/Admin/admin-page.php
+++ b/src/Admin/admin-page.php
@@ -41,6 +41,13 @@ if ( isset($_POST['section']) ) {
             echo "<div class=\"notice notice-success is-dismissible\"><p><strong>" . __('Settings saved.', 'wordpress-popular-posts') . "</strong></p></div>";
         }
     }
+    elseif ('wpml'== $_POST['section'] ) {
+        $current = 'tools';
+        if ( isset($_POST['wpp-admin-token'] ) && wp_verify_nonce($_POST['wpp-admin-token'], 'wpp-update-wpml-options') ) {
+            $this->config['tools']['wpml']['view_default_laguage'] = $_POST['view_default_laguage'];
+            update_option('wpp_settings_config', $this->config);
+            echo "<div class=\"notice notice-success is-dismissible\"><p><strong>" . __('Settings saved.', 'wordpress-popular-posts') . "</strong></p></div>";
+        }    } 
     elseif ( "thumb" == $_POST['section'] ) {
         $current = 'tools';
 
@@ -613,6 +620,37 @@ if ( ! $wpp_rand = get_option("wpp_rand") ) {
 
             <?php wp_nonce_field('wpp-update-misc-options', 'wpp-admin-token'); ?>
         </form>
+        
+        <?php if ( defined('ICL_LANGUAGE_CODE') ) : ?>
+            <br />
+            <p style="display: block; float: none; clear: both;">&nbsp;</p>
+            
+            <h3 class="wmpp-subtitle"><?php _e("WPML", 'wordpress-popular-posts'); ?></h3>
+
+            <form action="" method="post" id="wpp_wpml_options" name="wpp_wpml_options">
+                <table class="form-table">
+                    <tbody>
+                        <tr valign="top">
+                            <th scope="row"><label for="view_default_laguage"><?php _e("Post ID record", 'wordpress-popular-posts'); ?>:</label></th>
+                            <td>
+                                <select name="view_default_laguage" id="view_default_laguage">
+                                    <option <?php if ($this->config['tools']['wpml']['view_default_laguage'] === 'true') { ?>selected="selected"<?php } ?> value="true"><?php _e("View as default language", 'wordpress-popular-posts'); ?></option>
+                                    <option <?php if ($this->config['tools']['wpml']['view_default_laguage'] === 'false') { ?>selected="selected"<?php } ?> value="false"><?php _e("View as current language", 'wordpress-popular-posts'); ?></option>
+                                </select>
+                                <br />
+                            </td>
+                        </tr>
+                        <tr valign="top">
+                            <td colspan="2">
+                                <input type="hidden" name="section" value="wpml">
+                                <input type="submit" class="button-primary action" value="<?php _e("Apply", 'wordpress-popular-posts'); ?>" name="">
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <?php wp_nonce_field('wpp-update-wpml-options', 'wpp-admin-token'); ?>
+            </form>
+        <?php endif; ?>
         <br />
         <p style="display: block; float: none; clear: both;">&nbsp;</p>
 

--- a/src/Front/Front.php
+++ b/src/Front/Front.php
@@ -163,12 +163,15 @@ class Front {
         $table = $wpdb->prefix . "popularposts";
         $wpdb->show_errors();
 
+
+        $options = Settings::get('admin_options');
+        $default_language_post_id = $options['tools']['wpml']['view_default_laguage'];
         // Get translated object ID
         $post_ID = $this->translate->get_object_id(
             $post_ID,
             get_post_type($post_ID),
             true,
-            $this->translate->get_current_language()
+            $default_language_post_id === 'true' ? $this->translate->get_default_language() : $this->translate->get_current_language()
         );
         $now = Helper::now();
         $curdate = Helper::curdate();

--- a/src/Front/Front.php
+++ b/src/Front/Front.php
@@ -168,7 +168,7 @@ class Front {
             $post_ID,
             get_post_type($post_ID),
             true,
-            $this->translate->get_default_language()
+            $this->translate->get_current_language()
         );
         $now = Helper::now();
         $curdate = Helper::curdate();

--- a/src/Rest/Controller.php
+++ b/src/Rest/Controller.php
@@ -132,7 +132,7 @@ class Controller extends \WP_REST_Controller {
             $post_ID,
             get_post_type($post_ID),
             true,
-            $this->translate->get_default_language()
+            $this->translate->get_current_language()
         );
 
         $now = Helper::now();

--- a/src/Rest/Controller.php
+++ b/src/Rest/Controller.php
@@ -3,6 +3,7 @@ namespace WordPressPopularPosts\Rest;
 
 use WordPressPopularPosts\Helper;
 use WordPressPopularPosts\Query;
+use WordPressPopularPosts\Settings;
 
 class Controller extends \WP_REST_Controller {
 
@@ -127,12 +128,14 @@ class Controller extends \WP_REST_Controller {
         $table = $wpdb->prefix . "popularposts";
         $wpdb->show_errors();
 
+        $options = Settings::get('admin_options');
+        $default_language_post_id = $options['tools']['wpml']['view_default_laguage'];
         // Get translated object ID
         $post_ID = $this->translate->get_object_id(
             $post_ID,
             get_post_type($post_ID),
             true,
-            $this->translate->get_current_language()
+            $default_language_post_id === 'true' ? $this->translate->get_default_language() : $this->translate->get_current_language()
         );
 
         $now = Helper::now();

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -125,7 +125,10 @@ class Settings {
                 'sampling' => [
                     'active' => false,
                     'rate' => 100
-                ]
+                ],
+                'wpml' => [
+                    'view_default_laguage' => 'true'
+                ],
             ]
         ]
     ];


### PR DESCRIPTION
Hi Héctor,
I think that could be a nice option to have ...
For example in each home page ( of different languages ) i have the most read post and i think that is a nice feature to have the option to show just the most read post for each language and not in default language.
Believing this, I made an option setting in the tools page where you can choose what kind of post_id to pick, the default_language one or the current_language one.
I hope this is helpful.

Regards
Giovanni Polì