### PR TITLE
New Filter wpp_custom_header_html

### DIFF
--- a/src/Block/Widget/Widget.php
+++ b/src/Block/Widget/Widget.php
@@ -453,16 +453,14 @@ class Widget extends Block
             $query_args['author'] = '';
         }
 
-        $isTitle = ! empty($query_args['title'])
-                && ! empty($query_args['markup']['title-start'])
-                && ! empty($query_args['markup']['title-end']);
-        if ( $isTitle || has_filter('wpp_custom_header_html') ) {
-            if ( has_filter('wpp_custom_header_html') ) {
-                $html .= apply_filters('wpp_custom_header_html', $query_args);
-            } else {
-                $html .= htmlspecialchars_decode($query_args['markup']['title-start'], ENT_QUOTES) . $query_args['title'] . htmlspecialchars_decode($query_args['markup']['title-end'], ENT_QUOTES);
-            }
-            $html = Helper::sanitize_html($html, $query_args);
+        if ( 
+            ! empty($query_args['title'])
+            && ! empty($query_args['markup']['title-start'])
+            && ! empty($query_args['markup']['title-end']) ) {
+            $header_html = htmlspecialchars_decode($query_args['markup']['title-start'], ENT_QUOTES) . $query_args['title'] . htmlspecialchars_decode($query_args['markup']['title-end'], ENT_QUOTES);;
+            $header_html = apply_filters('wpp_custom_header_html', $header_html, $query_args);
+            $header_html = Helper::sanitize_html($header_html, $query_args);
+            $html .= $header_html;
         }
 
         $isAdmin = isset($_GET['isSelected']) ? $_GET['isSelected'] : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- isSelected is a boolean from wp-admin

--- a/src/Block/Widget/Widget.php
+++ b/src/Block/Widget/Widget.php
@@ -452,18 +452,17 @@ class Widget extends Block
         if ( empty($ids) ) {
             $query_args['author'] = '';
         }
-        if ( has_filter('wpp_custom_header_html') ) {
-            $html .= apply_filters('wpp_custom_header_html', $query_args);
-        } else {
-            // Has user set a title?
-            if (
-                ! empty($query_args['title'])
+
+        $isTitle = ! empty($query_args['title'])
                 && ! empty($query_args['markup']['title-start'])
-                && ! empty($query_args['markup']['title-end'])
-            ) {
+                && ! empty($query_args['markup']['title-end']);
+        if ( $isTitle || has_filter('wpp_custom_header_html') ) {
+            if ( has_filter('wpp_custom_header_html') ) {
+                $html .= apply_filters('wpp_custom_header_html', $query_args);
+            } else {
                 $html .= htmlspecialchars_decode($query_args['markup']['title-start'], ENT_QUOTES) . $query_args['title'] . htmlspecialchars_decode($query_args['markup']['title-end'], ENT_QUOTES);
-                $html = Helper::sanitize_html($html, $query_args);
             }
+            $html = Helper::sanitize_html($html, $query_args);
         }
 
         $isAdmin = isset($_GET['isSelected']) ? $_GET['isSelected'] : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- isSelected is a boolean from wp-admin

--- a/src/Block/Widget/Widget.php
+++ b/src/Block/Widget/Widget.php
@@ -452,15 +452,18 @@ class Widget extends Block
         if ( empty($ids) ) {
             $query_args['author'] = '';
         }
-
-        // Has user set a title?
-        if (
-            ! empty($query_args['title'])
-            && ! empty($query_args['markup']['title-start'])
-            && ! empty($query_args['markup']['title-end'])
-        ) {
-            $html .= htmlspecialchars_decode($query_args['markup']['title-start'], ENT_QUOTES) . $query_args['title'] . htmlspecialchars_decode($query_args['markup']['title-end'], ENT_QUOTES);
-            $html = Helper::sanitize_html($html, $query_args);
+        if ( has_filter('wpp_custom_header_html') ) {
+            $html .= apply_filters('wpp_custom_header_html', $query_args);
+        } else {
+            // Has user set a title?
+            if (
+                ! empty($query_args['title'])
+                && ! empty($query_args['markup']['title-start'])
+                && ! empty($query_args['markup']['title-end'])
+            ) {
+                $html .= htmlspecialchars_decode($query_args['markup']['title-start'], ENT_QUOTES) . $query_args['title'] . htmlspecialchars_decode($query_args['markup']['title-end'], ENT_QUOTES);
+                $html = Helper::sanitize_html($html, $query_args);
+            }
         }
 
         $isAdmin = isset($_GET['isSelected']) ? $_GET['isSelected'] : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- isSelected is a boolean from wp-admin

--- a/src/Shortcode/Posts.php
+++ b/src/Shortcode/Posts.php
@@ -208,15 +208,18 @@ class Posts extends Shortcode {
 
         $shortcode_content = '';
         $cached = false;
-
-        // is there a title defined by user?
-        if (
-            ! empty($header)
-            && ! empty($header_start)
-            && ! empty($header_end)
-        ) {
-            $shortcode_content .= htmlspecialchars_decode($header_start, ENT_QUOTES) . $header . htmlspecialchars_decode($header_end, ENT_QUOTES);
-            $shortcode_content = Helper::sanitize_html($shortcode_content, $shortcode_ops);
+        if ( has_filter('wpp_custom_header_html') ) {
+            $shortcode_content .= apply_filters('wpp_custom_header_html', $shortcode_ops);
+        } else {
+            // is there a title defined by user?
+            if (
+                ! empty($header)
+                && ! empty($header_start)
+                && ! empty($header_end)
+            ) {
+                $shortcode_content .= htmlspecialchars_decode($header_start, ENT_QUOTES) . $header . htmlspecialchars_decode($header_end, ENT_QUOTES);
+                $shortcode_content = Helper::sanitize_html($shortcode_content, $shortcode_ops);
+            }
         }
 
         $isAdmin = isset($_GET['isSelected']) ? $_GET['isSelected'] : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- isSelected is a boolean from wp-admin

--- a/src/Shortcode/Posts.php
+++ b/src/Shortcode/Posts.php
@@ -208,18 +208,17 @@ class Posts extends Shortcode {
 
         $shortcode_content = '';
         $cached = false;
-        if ( has_filter('wpp_custom_header_html') ) {
-            $shortcode_content .= apply_filters('wpp_custom_header_html', $shortcode_ops);
-        } else {
-            // is there a title defined by user?
-            if (
-                ! empty($header)
-                && ! empty($header_start)
-                && ! empty($header_end)
-            ) {
+
+        $isHeader = ! empty($header)
+                 && ! empty($header_start)
+                 && ! empty($header_end);
+        if ( $isHeader || has_filter('wpp_custom_header_html') ) {
+            if ( has_filter('wpp_custom_header_html') ) {
+                $shortcode_content .= apply_filters('wpp_custom_header_html', $shortcode_ops);
+            } else {
                 $shortcode_content .= htmlspecialchars_decode($header_start, ENT_QUOTES) . $header . htmlspecialchars_decode($header_end, ENT_QUOTES);
-                $shortcode_content = Helper::sanitize_html($shortcode_content, $shortcode_ops);
             }
+            $shortcode_content = Helper::sanitize_html($shortcode_content, $shortcode_ops);
         }
 
         $isAdmin = isset($_GET['isSelected']) ? $_GET['isSelected'] : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- isSelected is a boolean from wp-admin

--- a/src/Shortcode/Posts.php
+++ b/src/Shortcode/Posts.php
@@ -209,16 +209,14 @@ class Posts extends Shortcode {
         $shortcode_content = '';
         $cached = false;
 
-        $isHeader = ! empty($header)
-                 && ! empty($header_start)
-                 && ! empty($header_end);
-        if ( $isHeader || has_filter('wpp_custom_header_html') ) {
-            if ( has_filter('wpp_custom_header_html') ) {
-                $shortcode_content .= apply_filters('wpp_custom_header_html', $shortcode_ops);
-            } else {
-                $shortcode_content .= htmlspecialchars_decode($header_start, ENT_QUOTES) . $header . htmlspecialchars_decode($header_end, ENT_QUOTES);
-            }
-            $shortcode_content = Helper::sanitize_html($shortcode_content, $shortcode_ops);
+        if ( 
+            ! empty($header)
+            && ! empty($header_start)
+            && ! empty($header_end) ) {
+                $header_html = htmlspecialchars_decode($header_start, ENT_QUOTES) . $header . htmlspecialchars_decode($header_end, ENT_QUOTES);
+                $header_html = apply_filters('wpp_custom_header_html', $header_html, $shortcode_ops);
+                $header_html = Helper::sanitize_html($header_html, $shortcode_ops);
+                $shortcode_content .= $header_html;
         }
 
         $isAdmin = isset($_GET['isSelected']) ? $_GET['isSelected'] : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- isSelected is a boolean from wp-admin

--- a/src/Widget/Widget.php
+++ b/src/Widget/Widget.php
@@ -141,26 +141,21 @@ class Widget extends \WP_Widget {
 
         echo "\n" . $before_widget . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-        if ( '' != $instance['title'] || has_filter('wpp_custom_header_html') ) {
+        if ( '' != $instance['title'] ) {
             $header_html = '';
-            // Has user set a title?
-            if ( has_filter('wpp_custom_header_html') ) {
-                $header_html = apply_filters('wpp_custom_header_html', $instance);
+            $title = apply_filters('widget_title', $instance['title'], $instance, $this->id_base);
+            if (
+                $instance['markup']['custom_html']
+                && $instance['markup']['title-start'] != ''
+                && $instance['markup']['title-end'] != ''
+            ) {
+                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                $header_html = htmlspecialchars_decode($instance['markup']['title-start'], ENT_QUOTES) . $title . htmlspecialchars_decode($instance['markup']['title-end'], ENT_QUOTES);
             } else {
-                $title = apply_filters('widget_title', $instance['title'], $instance, $this->id_base);
-
-                if (
-                    $instance['markup']['custom_html']
-                    && $instance['markup']['title-start'] != ''
-                    && $instance['markup']['title-end'] != ''
-                ) {
-                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                    $header_html = htmlspecialchars_decode($instance['markup']['title-start'], ENT_QUOTES) . $title . htmlspecialchars_decode($instance['markup']['title-end'], ENT_QUOTES);
-                } else {
-                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                    $header_html = $before_title . $title . $after_title;
-                }
+                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                $header_html = $before_title . $title . $after_title;
             }
+            $header_html = apply_filters('wpp_custom_header_html', $header_html, $query_args);
             $header_html = Helper::sanitize_html($header_html, $query_args);
             echo $header_html;
         }

--- a/src/Widget/Widget.php
+++ b/src/Widget/Widget.php
@@ -140,21 +140,24 @@ class Widget extends \WP_Widget {
         );
 
         echo "\n" . $before_widget . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        if ( has_filter('wpp_custom_header_html') ) {
+            echo apply_filters('wpp_custom_header_html', $instance);
+        } else {
+            // Has user set a title?
+            if ( '' != $instance['title'] ) {
+                $title = apply_filters('widget_title', $instance['title'], $instance, $this->id_base);
 
-        // Has user set a title?
-        if ( '' != $instance['title'] ) {
-            $title = apply_filters('widget_title', $instance['title'], $instance, $this->id_base);
-
-            if (
-                $instance['markup']['custom_html']
-                && $instance['markup']['title-start'] != ''
-                && $instance['markup']['title-end'] != ''
-            ) {
-                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                echo htmlspecialchars_decode($instance['markup']['title-start'], ENT_QUOTES) . $title . htmlspecialchars_decode($instance['markup']['title-end'], ENT_QUOTES);
-            } else {
-                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                echo $before_title . $title . $after_title;
+                if (
+                    $instance['markup']['custom_html']
+                    && $instance['markup']['title-start'] != ''
+                    && $instance['markup']['title-end'] != ''
+                ) {
+                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                    echo htmlspecialchars_decode($instance['markup']['title-start'], ENT_QUOTES) . $title . htmlspecialchars_decode($instance['markup']['title-end'], ENT_QUOTES);
+                } else {
+                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                    echo $before_title . $title . $after_title;
+                }
             }
         }
 

--- a/src/Widget/Widget.php
+++ b/src/Widget/Widget.php
@@ -140,11 +140,13 @@ class Widget extends \WP_Widget {
         );
 
         echo "\n" . $before_widget . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        if ( has_filter('wpp_custom_header_html') ) {
-            echo apply_filters('wpp_custom_header_html', $instance);
-        } else {
+
+        if ( '' != $instance['title'] || has_filter('wpp_custom_header_html') ) {
+            $header_html = '';
             // Has user set a title?
-            if ( '' != $instance['title'] ) {
+            if ( has_filter('wpp_custom_header_html') ) {
+                $header_html = apply_filters('wpp_custom_header_html', $instance);
+            } else {
                 $title = apply_filters('widget_title', $instance['title'], $instance, $this->id_base);
 
                 if (
@@ -153,12 +155,14 @@ class Widget extends \WP_Widget {
                     && $instance['markup']['title-end'] != ''
                 ) {
                     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                    echo htmlspecialchars_decode($instance['markup']['title-start'], ENT_QUOTES) . $title . htmlspecialchars_decode($instance['markup']['title-end'], ENT_QUOTES);
+                    $header_html = htmlspecialchars_decode($instance['markup']['title-start'], ENT_QUOTES) . $title . htmlspecialchars_decode($instance['markup']['title-end'], ENT_QUOTES);
                 } else {
                     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                    echo $before_title . $title . $after_title;
+                    $header_html = $before_title . $title . $after_title;
                 }
             }
+            $header_html = Helper::sanitize_html($header_html, $query_args);
+            echo $header_html;
         }
 
         // Expose Widget ID & base for customization


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Popular Posts! -->

## What?
This PR provides a filter `wpp_custom_header_html` which can be used to fully customize the HTML code for the popular post's header. Using this filter, other header customization options like shortcode params, themes, etc. are overridden.

## Why?
I some cases the customization options provided aren't sufficient (e.g. see [here](https://wordpress.org/support/topic/how-to-use-a-post-template-to-display-in-popular-post-list/)). Thankfully, there's a `wpp_custom_html` filter which gives full control on the HTML output of the post list.

Unfortunately there's no such filter to customize the header. This PR fills the gap.

## How?
The PR makes little changes to the php files where HTML header code is generated. It just adds a new condition which checks if a filter has been provided and, if yes, applies this filter.

## Testing Instructions
1. Install the plugin in some WP site.
2. Append the code example given below to functions.php
3. Check the output by
    - inserting a widget
    - inserting some shortcode
    - inserting the WPP block in Gutenberg editor

### Code Example
```
function my_12345_wpp_header_html($instance) {
	return '<div class="my-custom-class">' . $instance['title'] . '</div>';
}
add_filter('wpp_custom_header_html', 'my_12345_wpp_header_html', 10, 2);
```

## Screenshots or screencast <!-- if applicable -->
