### PR TITLE
Fixes an undefined variable warning  in wpp_get_views()

### DIFF
--- a/src/template-tags.php
+++ b/src/template-tags.php
@@ -152,9 +152,7 @@ function wpp_get_views(int $id = null, $range = null, $number_format = true, $ca
             );
             //phpcs:enable
         }
-    }
-
-    if (isset($query)) {
+        
         $results = $wpdb->get_var($query); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- We already prepared $query above
     }
     

--- a/src/template-tags.php
+++ b/src/template-tags.php
@@ -154,8 +154,10 @@ function wpp_get_views(int $id = null, $range = null, $number_format = true, $ca
         }
     }
 
-    $results = $wpdb->get_var($query); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- We already prepared $query above
-
+    if (isset($query)) {
+        $results = $wpdb->get_var($query); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- We already prepared $query above
+    }
+    
     if ( ! $results ) {
         return 0;
     }


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Popular Posts! -->

## What?
`Warning: Undefined variable $query in /plugins/wordpress-popular-posts/src/template-tags.php on line 157`

## Why?
$query seems to be undefined when cache arg is used

## How?
Check if query exists before using it

## Testing Instructions
Use wpp_get_views on a page with with the following args:

```
if ( function_exists('wpp_get_views') ) {
    $wpp = wpp_get_views(
        $post->ID,
        "last24hours",
	false,
	true
    );
}
```
