### PR TITLE
Do not load wpp-js asynchronously 

### DIFF
--- a/src/Front/Front.php
+++ b/src/Front/Front.php
@@ -114,7 +114,6 @@ class Front {
             [
                 'id' => 'wpp-js',
                 'src' => $wpp_js_url,
-                'async' => true,
                 'data-sampling' => (int) $this->config['tools']['sampling']['active'],
                 'data-sampling-rate' => (int) $this->config['tools']['sampling']['rate'],
                 'data-api-url' => esc_url_raw(rest_url('wordpress-popular-posts')),


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Popular Posts! -->

## What?
Since 7.0.0, the script `wpp.js` (resp. `wpp.min.js`) is loaded asynchronously:
```
<script type="text/javascript" id="wpp-js" src="https://my-domain.com/wp-content/plugins/wordpress-popular-posts/assets/js/wpp.min.js" 
async="async" 
data-sampling="1" data-sampling-rate="50" data-api-url="https://my-domain.com/wp-json/wordpress-popular-posts" data-post-id="48107" data-token="0a5ed040f1" data-lang="0" data-debug="0"></script>
```

As stated [here](https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event), the `DOMContentLoaded` event **doesn't wait** for async scripts:
> The DOMContentLoaded event fires when the HTML document has been completely parsed, and all deferred scripts ([<script defer src="…">](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#defer) and [<script type="module">](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#module)) have downloaded and executed. **It doesn't wait** for other things like images, subframes, **and async scripts** to finish loading.

## Why?
As a result, using Safari, the event handler for `DOMContentLoaded` in `wpp.js`
```
document.addEventListener('DOMContentLoaded', function() {
```
is not triggered and the popular posts widget remains empty (i.e. shows a placeholder).

## How?
By removing the async param in the `wp_print_script_tag` in `Front.php` it's ensured that the script is being executed _before_ `DOMContentLoaded` is fired.

## Testing Instructions
1. Open a Post or Page in Safari.
2. Reload it several times. Mostly the Widget won't appear.

## Screenshots or screencast <!-- if applicable -->
<img width="375" alt="Bildschirmfoto 2024-07-05 um 11 53 28" src="https://github.com/cabrerahector/wordpress-popular-posts/assets/34437604/b70d34df-4d68-4192-9e72-ed76e3885e99">
